### PR TITLE
Implements OAuth Dance

### DIFF
--- a/pages2docs/Actions.fs
+++ b/pages2docs/Actions.fs
@@ -6,5 +6,37 @@ open Suave.Web             // for config
 open Suave.Filters
 open Suave.Writers
 open Suave.Operators
+open Suave.Redirection
 
 let helloWorld = OK "<html><body><h1>Welcome to Pages2Docs!</h1></body></html>\n"
+
+let clientId =
+    match Some(System.Environment.GetEnvironmentVariable("GH_CLIENT_ID")) with
+    | Some key -> key
+    | None -> "MISSING"
+
+let redirectUrl =
+    match Some(System.Environment.GetEnvironmentVariable("GH_REDIRECT_URL")) with
+    | Some key -> key
+    | None -> "https://localhost:5000/auth/complete"
+
+
+let scope = "public_repo"
+let state = System.Guid.NewGuid().ToString()
+
+let startAuth : WebPart = 
+    let p = "https://github.com/login/oauth/authorize"
+    let q = (sprintf "?client_id=%s&&redirect_uri=%s&scope=%s&state=%s" clientId redirectUrl scope state) 
+    redirect p
+
+let authComplete : WebPart = request (fun req ->
+    let clientId =     match (req.formData "client_id") with
+                        | Choice1Of2 t -> t
+                        | Choice2Of2 t -> "MISSING"
+    let clientSecret = match (req.formData "client_secret") with
+                        | Choice1Of2 t -> t
+                        | Choice2Of2 t -> "MISSING"
+    let code =         match (req.formData "code") with
+                        | Choice1Of2 t -> t
+                        | Choice2Of2 t -> "MISSING"
+    OK code)

--- a/pages2docs/Program.fs
+++ b/pages2docs/Program.fs
@@ -14,7 +14,10 @@ module Program =
   let app =
     choose
       [ GET >=> choose
-          [ path "/" >=> helloWorld]]
+          [ path "/" >=> helloWorld
+            path "/auth" >=> startAuth]
+        POST >=> choose 
+          [ path "/auth/handshake" >=> authComplete]]
 
   let port =
       match System.UInt16.TryParse(System.Environment.GetEnvironmentVariable("PORT")) with


### PR DESCRIPTION
Closes #1 when done.

Build out initiating route `/auth`
- redirects to Github per https://developer.github.com/v3/oauth/

Build out handshake route `/auth/handshake`
- takes data and makes an HTTP request per spec to get the access_token
- stores access token in session at `github_access_token`

With those two steps auth with GitHub should be done.

NOTE: We are not storing the token

ISSUE: accessing form data is not working as expected
